### PR TITLE
remove obsolete grafana stack code

### DIFF
--- a/newrelic/start.sh
+++ b/newrelic/start.sh
@@ -10,30 +10,3 @@ export MONITORING_STACK="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && 
 
 echo -e "Launch cp-demo in $CP_DEMO_HOME (version $CP_DEMO_VERSION) and monitoring stack in $MONITORING_STACK"
 (cd $CP_DEMO_HOME && ./scripts/start.sh)
-
-
-
-########################################
-# Start monitoring solution
-########################################
-
-echo -e "Create user and certificates for kafkaLagExporter"
-KAFKA_LAG_EXPORTER="User:kafkaLagExporter"
-SECURITY_DIR="${MONITORING_STACK}/assets/prometheus/security"
-mkdir -p $SECURITY_DIR
-(cd $SECURITY_DIR && rm -f *.crt *.csr *_creds *.jks *.srl *.key *.pem *.der *.p12)
-(cd $SECURITY_DIR && $CP_DEMO_HOME/scripts/security/certs-create-per-user.sh kafkaLagExporter)
-
-echo -e "Create role binding for kafkaLagExporter"
-cd $CP_DEMO_HOME
-KAFKA_CLUSTER_ID=$(docker-compose exec zookeeper zookeeper-shell zookeeper:2181 get /cluster/id 2> /dev/null | grep \"version\" | jq -r .id)
-docker-compose exec tools bash -c "confluent iam rolebinding create \
-    --principal $KAFKA_LAG_EXPORTER \
-    --role SystemAdmin \
-    --kafka-cluster-id $KAFKA_CLUSTER_ID"
-
-echo -e "Launch $MONITORING_STACK"
-docker-compose up -d prometheus node-exporter kafka-lag-exporter grafana
-
-echo -e "\nView Grafana dashboards at (admin/password) ->"
-echo -e "http://localhost:3000"


### PR DESCRIPTION
This PR cleans up a few unnecessary commands from the `start.sh` script. They were leftover from copying from the prometheus/grafan folder and aren't needed for the newrelic demo